### PR TITLE
テストコードを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@
 ## lint
 
 `./vendor/bin/sail run ./vendor/bin/phpstan analyse`
+
+## テスト
+
+`./vendor/bin/sail run php artisan test`

--- a/app/Http/Requests/ContactRequest.php
+++ b/app/Http/Requests/ContactRequest.php
@@ -30,7 +30,7 @@ class ContactRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'email' => 'required|email',
+            'email' => 'required|email|max:255',
             'message' => 'required|string',
         ];
     }

--- a/app/Http/Requests/ContactRequest.php
+++ b/app/Http/Requests/ContactRequest.php
@@ -31,7 +31,7 @@ class ContactRequest extends FormRequest
         return [
             'name' => 'required|string|max:255',
             'email' => 'required|email|max:255',
-            'message' => 'required|string',
+            'message' => 'required|string|max:1000',
         ];
     }
 }

--- a/tests/Feature/ContactApiTest.php
+++ b/tests/Feature/ContactApiTest.php
@@ -52,4 +52,30 @@ class ContactApiTest extends TestCase
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['email']);
     }
+
+    public function test_store_missing_email()
+    {
+        $response = $this->postJson('/api/contact', [
+            'name' => 'テストユーザー',
+            // emailを省略
+            'message' => '内容'
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
+
+    public function test_store_message_too_long()
+    {
+        $longMessage = str_repeat('a', 10001); // 極端に長いメッセージ
+        $response = $this->postJson('/api/contact', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'message' => $longMessage
+        ]);
+
+        // messageにmax制限がなければ、このテストは失敗するので、必要に応じてバリデーション追加を検討してください
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['message']);
+    }
 }

--- a/tests/Feature/ContactApiTest.php
+++ b/tests/Feature/ContactApiTest.php
@@ -39,4 +39,17 @@ class ContactApiTest extends TestCase
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['name', 'email', 'message']);
     }
+
+    public function test_store_email_too_long()
+    {
+        $longEmail = str_repeat('a', 256) . '@example.com';
+        $response = $this->postJson('/api/contact', [
+            'name' => 'テストユーザー',
+            'email' => $longEmail,
+            'message' => 'テスト'
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    }
 }

--- a/tests/Feature/ContactApiTest.php
+++ b/tests/Feature/ContactApiTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Contact;
+
+class ContactApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_success()
+    {
+        $response = $this->postJson('/api/contact', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'message' => 'お問い合わせ内容'
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson(['message' => '問い合わせを受け付けました。']);
+
+        $this->assertDatabaseHas('contacts', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'message' => 'お問い合わせ内容'
+        ]);
+    }
+
+    public function test_store_validation_error()
+    {
+        $response = $this->postJson('/api/contact', [
+            'name' => '', // nameが空
+            'email' => 'invalid-email',
+            'message' => ''
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['name', 'email', 'message']);
+    }
+}

--- a/tests/Unit/ContactSubmitUseCaseTest.php
+++ b/tests/Unit/ContactSubmitUseCaseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Domain\Contact\ContactRepositoryInterface;
+use App\UseCases\Contact\ContactSubmitUseCase;
+use PHPUnit\Framework\TestCase;
+use App\Domain\Contact\Contact;
+
+class ContactSubmitUseCaseTest extends TestCase
+{
+    public function test_handle_calls_repository_save()
+    {
+        // Arrange: ContactRepositoryInterfaceのMock作成
+        $mockRepo = $this->createMock(ContactRepositoryInterface::class);
+        $mockRepo->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function ($contact) {
+                return $contact instanceof Contact
+                    && $contact->getName() === 'テストユーザー'
+                    && $contact->getEmail() === 'test@example.com'
+                    && $contact->getMessage() === 'テストメッセージ';
+            }));
+
+        $useCase = new ContactSubmitUseCase($mockRepo);
+
+        // Act
+        $useCase->handle('テストユーザー', 'test@example.com', 'テストメッセージ');
+    }
+}

--- a/tests/Unit/ContactTest.php
+++ b/tests/Unit/ContactTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Domain\Contact\Contact;
+use PHPUnit\Framework\TestCase;
+
+class ContactTest extends TestCase
+{
+    public function test_contact_getters()
+    {
+        $contact = new Contact('ユーザー', 'user@example.com', 'メッセージ');
+        $this->assertSame('ユーザー', $contact->getName());
+        $this->assertSame('user@example.com', $contact->getEmail());
+        $this->assertSame('メッセージ', $contact->getMessage());
+    }
+}


### PR DESCRIPTION
# やったこと
- テストコードを追加

# 結果
```
./vendor/bin/sail run php artisan test

   PASS  Tests\Unit\ContactSubmitUseCaseTest
  ✓ handle calls repository save

   PASS  Tests\Unit\ContactTest
  ✓ contact getters

   PASS  Tests\Unit\ExampleTest
  ✓ that true is true

   PASS  Tests\Feature\ContactApiTest
  ✓ store success                                0.34s
  ✓ store validation error                       0.01s
  ✓ store email too long                         0.01s
  ✓ store missing email                          0.01s
  ✓ store message too long                       0.01s

   PASS  Tests\Feature\ExampleTest
  ✓ the application returns a successful respon… 0.01s

  Tests:    9 passed (24 assertions)
  Duration: 0.43s
```